### PR TITLE
Add convenience methods to create IDMPhoto objects with ease.

### DIFF
--- a/Classes/IDMPhoto.h
+++ b/Classes/IDMPhoto.h
@@ -29,6 +29,10 @@ typedef void (^IDMProgressUpdateBlock)(CGFloat progress);
 + (IDMPhoto *)photoWithFilePath:(NSString *)path;
 + (IDMPhoto *)photoWithURL:(NSURL *)url;
 
++ (NSArray *)photosWithImages:(NSArray *)imagesArray;
++ (NSArray *)photosWithFilePaths:(NSArray *)pathsArray;
++ (NSArray *)photosWithURLs:(NSArray *)urlsArray;
+
 // Init
 - (id)initWithImage:(UIImage *)image;
 - (id)initWithFilePath:(NSString *)path;

--- a/Classes/IDMPhoto.m
+++ b/Classes/IDMPhoto.m
@@ -52,6 +52,45 @@ caption = _caption;
 	return [[IDMPhoto alloc] initWithURL:url];
 }
 
++ (NSArray *)photosWithImages:(NSArray *)imagesArray {
+    NSMutableArray *photos = [NSMutableArray arrayWithCapacity:imagesArray.count];
+    
+    for (UIImage *image in imagesArray) {
+        if ([image isKindOfClass:[UIImage class]]) {
+            IDMPhoto *photo = [IDMPhoto photoWithImage:image];
+            [photos addObject:photo];
+        }
+    }
+    
+    return photos;
+}
+
++ (NSArray *)photosWithFilePaths:(NSArray *)pathsArray {
+    NSMutableArray *photos = [NSMutableArray arrayWithCapacity:pathsArray.count];
+    
+    for (NSString *path in pathsArray) {
+        if ([path isKindOfClass:[NSString class]]) {
+            IDMPhoto *photo = [IDMPhoto photoWithFilePath:path];
+            [photos addObject:photo];
+        }
+    }
+    
+    return photos;
+}
+
++ (NSArray *)photosWithURLs:(NSArray *)urlsArray {
+    NSMutableArray *photos = [NSMutableArray arrayWithCapacity:urlsArray.count];
+    
+    for (NSURL *url in urlsArray) {
+        if ([url isKindOfClass:[NSURL class]]) {
+            IDMPhoto *photo = [IDMPhoto photoWithURL:url];
+            [photos addObject:photo];
+        }
+    }
+    
+    return photos;
+}
+
 #pragma mark NSObject
 
 - (id)initWithImage:(UIImage *)image {

--- a/Classes/IDMPhotoBrowser.h
+++ b/Classes/IDMPhotoBrowser.h
@@ -51,6 +51,12 @@
 // Init with animation
 - (id)initWithPhotos:(NSArray *)photosArray animatedFromView:(UIView*)view;
 
+// Init with NSURL objects
+- (id)initWithPhotoUrls:(NSArray *)photoUrlsArray;
+
+// Init with NSURL objects with animation
+- (id)initWithPhotoUrls:(NSArray *)photoUrlsArray animatedFromView:(UIView*)view;
+
 // Reloads the photo browser and refetches data
 - (void)reloadData;
 

--- a/Classes/IDMPhotoBrowser.m
+++ b/Classes/IDMPhotoBrowser.m
@@ -191,6 +191,24 @@
 	return self;
 }
 
+- (id)initWithPhotoUrls:(NSArray *)photoUrlsArray {
+    if ((self = [self init])) {
+        NSArray *photosArray = [IDMPhoto photosWithURLs:photoUrlsArray];
+		_newPhotos = [[NSMutableArray alloc] initWithArray:photosArray];
+	}
+	return self;
+}
+
+- (id)initWithPhotoUrls:(NSArray *)photoUrlsArray animatedFromView:(UIView*)view {
+    if ((self = [self init])) {
+        NSArray *photosArray = [IDMPhoto photosWithURLs:photoUrlsArray];
+		_newPhotos = [[NSMutableArray alloc] initWithArray:photosArray];
+        
+        [self performAnimationWithView:view];
+	}
+	return self;
+}
+
 - (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [self releaseAllUnderlyingPhotos];

--- a/README.markdown
+++ b/README.markdown
@@ -51,6 +51,9 @@ First create a photos array containing IDMPhoto objects:
         IDMPhoto *photo = [IDMPhoto photoWithURL:url];
     	[photos addObject:photo];
     }
+	
+    // Or use this constructor to receive an NSArray of IDMPhoto objects from your NSURL objects
+    NSArray *photos = [IDMPhoto photosWithURLs:photosURL];
 ````
 
 There are two main ways to presente the photoBrowser: With a fade on screen or with a zooming effect from an existing view.


### PR DESCRIPTION
Created a few constructor methods to create IDMPhoto objects from arrays of NSURL, NSString and UIImage.

I'm using this project but it seems nicer to provide ways to use IDMPhotoBrowser without requiring that they create IDMPhoto objects first, so I added methods to bypass that step, as well as modifying the README to show the new method.
