### PR TITLE
disable unnecessary animated dismiss

### DIFF
--- a/Classes/IDMPhotoBrowser.m
+++ b/Classes/IDMPhotoBrowser.m
@@ -1264,7 +1264,7 @@ static inline double radians (double degrees) {return degrees * M_PI/180;}
         [self performCloseAnimationWithScrollView:scrollView];
     }
     
-    [self dismissViewControllerAnimated:YES completion:^{
+    [self dismissViewControllerAnimated:[sender isKindOfClass:[UIButton class]] completion:^{
         if ([_delegate respondsToSelector:@selector(photoBrowser:didDismissAtPageIndex:)])
             [_delegate photoBrowser:self didDismissAtPageIndex:_currentPageIndex];
         


### PR DESCRIPTION
I experienced, that when the user swipes down the image, the rest of the UI freezes for a short time.
