### PR TITLE
Allow iOS 6 in pod spec

### DIFF
--- a/IDMPhotoBrowser.podspec
+++ b/IDMPhotoBrowser.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.license       =  { :type => 'MIT', :file => 'LICENSE.txt' }
   s.author        =  { "Ideais Mobile" => "mobile@ideais.com.br" }
   s.source        =  { :git => "https://github.com/ideaismobile/IDMPhotoBrowser.git", :tag => "1.3.2" }
-  s.platform      =  :ios, '7.0'
+  s.platform      =  :ios, '6.0'
   s.source_files  =  'Classes/*.{h,m}'
   s.resources     =  'Classes/IDMPhotoBrowser.bundle'
   s.framework     =  'MessageUI', 'QuartzCore', 'SystemConfiguration', 'MobileCoreServices', 'Security'


### PR DESCRIPTION
Seems like an oversight in the latest podspec as I've tested the latest 1.3.2 code on iOS 6.0 and it seems to be working without issue.

See issue https://github.com/ideaismobile/IDMPhotoBrowser/issues/47
