### PR TITLE
iOS 8 transition fixes

### DIFF
--- a/Classes/IDMPhotoBrowser.m
+++ b/Classes/IDMPhotoBrowser.m
@@ -520,6 +520,10 @@ NSLocalizedStringFromTableInBundle((key), nil, [NSBundle bundleWithPath:[[NSBund
 }
 
 - (UIImage*)getImageFromView:(UIView *)view {
+    if ([view isKindOfClass:[UIImageView class]]) {
+        return ((UIImageView *)view).image;
+    }
+    
     UIGraphicsBeginImageContextWithOptions(view.bounds.size, YES, 2);
     [view.layer renderInContext:UIGraphicsGetCurrentContext()];
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();


### PR DESCRIPTION
Switched to using the new UIModalPresentation contexts in iOS 8 to fix the fading effects. Also maintained iOS 7 compatibility.

Fixed a few animation glitches taking place on iOS 8 as well.
