### PR TITLE
fix crash on iPad/iOS8 when click share button

### DIFF
--- a/Classes/IDMPhotoBrowser.m
+++ b/Classes/IDMPhotoBrowser.m
@@ -1239,7 +1239,9 @@ NSLocalizedStringFromTableInBundle((key), nil, [NSBundle bundleWithPath:[[NSBund
                 selfBlock.activityViewController = nil;
             }];
             
-            self.activityViewController.popoverPresentationController.barButtonItem = sender;
+            if ([self.activityViewController respondsToSelector:@selector(popoverPresentationController)]) {
+                [self.activityViewController.popoverPresentationController setBarButtonItem:sender];
+            }
             
             [self presentViewController:self.activityViewController animated:YES completion:nil];
         }


### PR DESCRIPTION
Fix the following exception:

Terminating app due to uncaught exception 'NSGenericException', reason: 'UIPopoverPresentationController (<_UIAlertControllerActionSheetRegularPresentationController: 0x7a57ca60>) should have a non-nil sourceView or barButtonItem set before the presentation occurs.'
