### PR TITLE
Issue 108 - Option for always displaying image caption

### DIFF
--- a/Classes/IDMPhotoBrowser.h
+++ b/Classes/IDMPhotoBrowser.h
@@ -34,6 +34,7 @@
 @property (nonatomic) BOOL displayCounterLabel;
 @property (nonatomic) BOOL displayArrowButton;
 @property (nonatomic) BOOL displayActionButton;
+@property (nonatomic) BOOL alwaysShowCaptions;
 @property (nonatomic, strong) NSArray *actionButtonTitles;
 @property (nonatomic, weak) UIImage *leftArrowImage, *leftArrowSelectedImage;
 @property (nonatomic, weak) UIImage *rightArrowImage, *rightArrowSelectedImage;

--- a/Classes/IDMPhotoBrowser.m
+++ b/Classes/IDMPhotoBrowser.m
@@ -848,7 +848,8 @@ NSLocalizedStringFromTableInBundle((key), nil, [NSBundle bundleWithPath:[[NSBund
             if ([photo caption]) captionView = [[IDMCaptionView alloc] initWithPhoto:photo];
         }
     }
-    captionView.alpha = [self areControlsHidden] ? 0 : 1; // Initial alpha
+
+    captionView.alpha = [self areControlsHidden] && !self.alwaysShowCaptions ? 0 : 1; // Initial alpha
     
     return captionView;
 }
@@ -1176,7 +1177,9 @@ NSLocalizedStringFromTableInBundle((key), nil, [NSBundle bundleWithPath:[[NSBund
         [self.navigationController.navigationBar setAlpha:alpha];
         [_toolbar setAlpha:alpha];
         [_doneButton setAlpha:alpha];
-        for (UIView *v in captionViews) v.alpha = alpha;
+
+        CGFloat captionAlpha = hidden && !self.alwaysShowCaptions ? 0 : 1;
+        for (UIView *v in captionViews) v.alpha = captionAlpha;
     } completion:^(BOOL finished) {}];
     
 	// Control hiding timer


### PR DESCRIPTION
Added a boolean value to set whether image caption always displays.  This is handled in the toggle during the timer fire and also when the next/previous image is moved onto the view.