### PR TITLE
Fixed modalPresentationStyle broken in ios 7.x

### DIFF
--- a/Classes/IDMPhotoBrowser.m
+++ b/Classes/IDMPhotoBrowser.m
@@ -503,7 +503,7 @@ NSLocalizedStringFromTableInBundle((key), nil, [NSBundle bundleWithPath:[[NSBund
         if ([_delegate respondsToSelector:@selector(photoBrowser:didDismissAtPageIndex:)])
             [_delegate photoBrowser:self didDismissAtPageIndex:_currentPageIndex];
 		
-		if (SYSTEM_VERSION_LESS_THAN_OR_EQUAL_TO(@"7.0"))
+		if (SYSTEM_VERSION_LESS_THAN(@"8.0"))
 		{
 			_applicationTopViewController.modalPresentationStyle = _previousModalPresentationStyle;
 		}


### PR DESCRIPTION
If you present IDMPhotoBrowser under iOS 8.0
modalPresentationStyle of _applicationTopViewController is changed to UIModalPresentationCurrentContext as indicated in the init() method
but after you dismiss the IDMPhotoBrowser it doesn't set back to the original/previous modalPresentationStyle. So when you present any view controller in your app the slide up animation is broken. This pull request should fix that issue