### PR TITLE
Support frameworks by fixing non-local imports

### DIFF
--- a/Classes/IDMPhoto.h
+++ b/Classes/IDMPhoto.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import "IDMPhotoProtocol.h"
-#import "AFNetworking.h"
+#import <AFNetworking/AFNetworking.h>
 
 // This class models a photo/image and it's caption
 // If you want to handle photos, caching, decompression

--- a/Classes/IDMZoomingScrollView.h
+++ b/Classes/IDMZoomingScrollView.h
@@ -11,7 +11,7 @@
 #import "IDMTapDetectingImageView.h"
 #import "IDMTapDetectingView.h"
 
-#import "DACircularProgressView.h"
+#import <DACircularProgress/DACircularProgressView.h>
 
 @class IDMPhotoBrowser, IDMPhoto, IDMCaptionView;
 


### PR DESCRIPTION
Cocoapods 0.36.0 added support for frameworks. This PR allows IDMPhotoBrowser to be used as a framework.