### PR TITLE
iOS 8 Status Bar not hide fix

### DIFF
--- a/Classes/IDMPhotoBrowser.m
+++ b/Classes/IDMPhotoBrowser.m
@@ -191,6 +191,7 @@ NSLocalizedStringFromTableInBundle((key), nil, [NSBundle bundleWithPath:[[NSBund
 		{
 			self.modalPresentationStyle = UIModalPresentationCustom;
 			self.modalTransitionStyle = UIModalTransitionStyleCrossDissolve;
+            self.modalPresentationCapturesStatusBarAppearance = YES;
 		}
 		else
 		{


### PR DESCRIPTION
 http://stackoverflow.com/a/25334514 

Status Bar could't not hide in iOS8 if leave the `modalPresentationCapturesStatusBarAppearance` to the default value.