### PR TITLE
Fix status bar style

### DIFF
--- a/Classes/IDMPhotoBrowser.m
+++ b/Classes/IDMPhotoBrowser.m
@@ -695,7 +695,7 @@ NSLocalizedStringFromTableInBundle((key), nil, [NSBundle bundleWithPath:[[NSBund
 #pragma mark - Status Bar
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
-    return _useWhiteBackgroundColor ? 1 : 0;
+    return _useWhiteBackgroundColor ? UIStatusBarStyleDefault : UIStatusBarStyleLightContent;
 }
 
 - (BOOL)prefersStatusBarHidden {


### PR DESCRIPTION
In iOS 8, the status bar was not being correctly set. This commit updates the code to use the enums rather than the explicit integer values.