### PR TITLE
Use cookies when downloading images

### DIFF
--- a/Classes/IDMPhoto.m
+++ b/Classes/IDMPhoto.m
@@ -137,7 +137,7 @@ caption = _caption;
         } else if (_photoURL) {
             // Load async from web (using SDWebImageManager)
             SDWebImageManager *manager = [SDWebImageManager sharedManager];
-            [manager downloadImageWithURL:_photoURL options:SDWebImageRetryFailed progress:^(NSInteger receivedSize, NSInteger expectedSize) {
+            [manager downloadImageWithURL:_photoURL options:SDWebImageRetryFailed|SDWebImageHandleCookies progress:^(NSInteger receivedSize, NSInteger expectedSize) {
                 CGFloat progress = ((CGFloat)receivedSize)/((CGFloat)expectedSize);
                 if (self.progressUpdateBlock) {
                     self.progressUpdateBlock(progress);


### PR DESCRIPTION
I added the `SDWebImageHandleCookies` option to the photo downloader. 

I could extend this to be customizable outside of the class if needed, but it feels like a reasonable default and the solution is very low touch.