### PR TITLE
Use actual interface orientation instead of the device one

### DIFF
--- a/Classes/IDMZoomingScrollView.m
+++ b/Classes/IDMZoomingScrollView.m
@@ -52,8 +52,7 @@
         CGFloat screenWidth = screenBound.size.width;
         CGFloat screenHeight = screenBound.size.height;
         
-        if ([[UIDevice currentDevice] orientation] == UIDeviceOrientationLandscapeLeft ||
-            [[UIDevice currentDevice] orientation] == UIDeviceOrientationLandscapeRight) {
+        if ([[UIApplication sharedApplication] statusBarOrientation] == UIInterfaceOrientationLandscapeLeft || [[UIApplication sharedApplication] statusBarOrientation] == UIInterfaceOrientationLandscapeRight) {
             screenWidth = screenBound.size.height;
             screenHeight = screenBound.size.width;
         }


### PR DESCRIPTION
Use actual interface orientation instead of the device one to fix misplaced progress view when orientations do not match

Progress view is misplaced when the device is in landscape orientation, but application is portrait-only.