### PR TITLE
Do not perform present animation if sender view is not set

### DIFF
--- a/Classes/IDMPhotoBrowser.m
+++ b/Classes/IDMPhotoBrowser.m
@@ -613,7 +613,9 @@ NSLocalizedStringFromTableInBundle((key), nil, [NSBundle bundleWithPath:[[NSBund
 	[self.view addSubview:_pagingScrollView];
 
     // Transition animation
-    [self performPresentAnimation];
+    if (_senderViewForAnimation) {
+        [self performPresentAnimation];
+    }
 
     UIInterfaceOrientation currentOrientation = [UIApplication sharedApplication].statusBarOrientation;
 


### PR DESCRIPTION
Sender view is not set when presenting IDMPhotoBrowser using Peek and Pop 3D touch action.
Thus, no need to perform animation when presenting the view controller