### PR TITLE
Fix warning: MobileCoreServices has been renamed.

### DIFF
--- a/IDMPhotoBrowser.podspec
+++ b/IDMPhotoBrowser.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.platform      =  :ios, '8.0'
   s.source_files  =  'Classes/*.{h,m}'
   s.resources     =  'Classes/IDMPhotoBrowser.bundle', 'Classes/IDMPBLocalizations.bundle'
-  s.framework     =  'MessageUI', 'QuartzCore', 'SystemConfiguration', 'MobileCoreServices', 'Security'
+  s.framework     =  'MessageUI', 'QuartzCore', 'SystemConfiguration', 'Security'
   s.requires_arc  =  true
   s.dependency       'SDWebImage'
   s.dependency       'DACircularProgress'


### PR DESCRIPTION
Close #315

If our library was installed via CocoaPods, Xcode 11.4 will issue the warning "MobileCoreServices has been renamed. Use CoreServices instead.".

![image](https://user-images.githubusercontent.com/526008/77892980-eecffd80-72a5-11ea-891b-78acd78d4b7c.png)

How to fix: Do not explicitly link `MobileCoreServices.framework` in the CocoaPods generated project, by deleting `MobileCoreServices` from the `spec.frameworks` attribute in our podspec file.

More info: https://github.com/AFNetworking/AFNetworking/pull/4532
